### PR TITLE
Don't check e-mail addresses and URLs for spelling errors

### DIFF
--- a/src/php/aspell.php
+++ b/src/php/aspell.php
@@ -56,12 +56,12 @@ if ($text != NULL) {
     // to the client.
     set_error_handler("returnError");
 
+    // Get rid of anything containing @ : # ~ \ or / (hashtags, email addresses, URLs, etc.)
+    $text = preg_replace('/[\S]*[@\/\\:#~][\S]*/', '', $text);
+
     // Get rid of double-dashes, since we ignore dashes
     // when splitting words.
     $text = preg_replace('/--+/u', ' ', $text);
-
-    // Get rid of anything containing @ : # ~ or / (hashtags, email addresses, URLs, etc.)
-    $text = preg_replace('/[\S+)]*[@\/:#~][\S+)]*/', '', $text);
 
     // Split on anything that's not a word character, quote or dash
     $words = preg_split($splitRegexp, $text);

--- a/src/php/aspell.php
+++ b/src/php/aspell.php
@@ -60,6 +60,12 @@ if ($text != NULL) {
     // when splitting words.
     $text = preg_replace('/--+/u', ' ', $text);
 
+    // Get rid of e-mail addresses
+    $text = preg_replace("/[^@\s]*@[^@\s]*\.[^@\s]*/", ' ', $text);
+
+    // Get rid of URLs
+    $text = preg_replace("/[a-zA-Z]*[:\/\/]*[A-Za-z0-9\-_]+\.+[A-Za-z0-9\.\/%&=\?\-_]+/i", ' ', $text);
+
     // Split on anything that's not a word character, quote or dash
     $words = preg_split($splitRegexp, $text);
 	

--- a/src/php/aspell.php
+++ b/src/php/aspell.php
@@ -60,11 +60,8 @@ if ($text != NULL) {
     // when splitting words.
     $text = preg_replace('/--+/u', ' ', $text);
 
-    // Get rid of e-mail addresses
-    $text = preg_replace("/[^@\s]*@[^@\s]*\.[^@\s]*/", ' ', $text);
-
-    // Get rid of URLs
-    $text = preg_replace("/[a-zA-Z]*[:\/\/]*[A-Za-z0-9\-_]+\.+[A-Za-z0-9\.\/%&=\?\-_]+/i", ' ', $text);
+    // Get rid of anything containing @ : # ~ or / (hashtags, email addresses, URLs, etc.)
+    $text = preg_replace('/[\S+)]*[@\/:#~][\S+)]*/', '', $text);
 
     // Split on anything that's not a word character, quote or dash
     $words = preg_split($splitRegexp, $text);


### PR DESCRIPTION
Current spellcheck marks e-mail addresses and URLs as spelling mistakes, this patch removes them from the spellcheck.