### PR TITLE
Updating httpd.conf to load the libphp7.so module for the zimbra-php …

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -145,7 +145,7 @@ LoadModule dir_module /opt/zimbra/common/lib/apache2/modules/mod_dir.so
 LoadModule alias_module /opt/zimbra/common/lib/apache2/modules/mod_alias.so
 #LoadModule rewrite_module /opt/zimbra/common/lib/apache2/modules/mod_rewrite.so
 LoadModule mpm_event_module /opt/zimbra/common/lib/apache2/modules/mod_mpm_event.so
-LoadModule php5_module        /opt/zimbra/common/lib/apache2/modules/libphp5.so
+LoadModule php7_module        /opt/zimbra/common/lib/apache2/modules/libphp7.so
 
 <IfModule unixd_module>
 #


### PR DESCRIPTION
Updated the httpd.conf to fix the following issue 
`Starting apache...httpd: Syntax error on line 148 of /opt/zimbra/conf/httpd.conf: Cannot load /opt/zimbra/common/lib/apache2/modules/libphp5.so into server: /opt/zimbra/common/lib/apache2/modules/libphp5.so: cannot open shared object file: No such file or directory
failed. `

After updating the php version to zimbra-php 7.3.1 the above issue comes up with the zmapachectl restart. 

The quick fix was to update the httpd.conf to include the libphp7.so module to be loaded.  

I have updated the tag 8.8.11.p3 and the 8.8.10.p3 with the change. 