### PR TITLE
ZCS-14356 : Upgraded PHP to 8.3.0

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -145,7 +145,7 @@ LoadModule dir_module /opt/zimbra/common/lib/apache2/modules/mod_dir.so
 LoadModule alias_module /opt/zimbra/common/lib/apache2/modules/mod_alias.so
 #LoadModule rewrite_module /opt/zimbra/common/lib/apache2/modules/mod_rewrite.so
 LoadModule mpm_event_module /opt/zimbra/common/lib/apache2/modules/mod_mpm_event.so
-LoadModule php7_module        /opt/zimbra/common/lib/apache2/modules/libphp7.so
+LoadModule php_module        /opt/zimbra/common/lib/apache2/modules/libphp.so
 
 <IfModule unixd_module>
 #
@@ -493,3 +493,5 @@ SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
 </IfModule>
 
+ServerSignature Off
+ServerTokens Prod

--- a/src/php/aspell.php
+++ b/src/php/aspell.php
@@ -44,10 +44,8 @@ if (isset($_REQUEST["ignore"])) {
 if (isset($_REQUEST["ignoreAllCaps"]) && $_REQUEST["ignoreAllCaps"] == "on") {
   $ignoreAllCaps = TRUE;	
 }
-   
-if (get_magic_quotes_gpc()) {
-    $text = stripslashes($text);
-}
+
+$text = stripslashes($text);
 
 if ($text != NULL) {
     setlocale(LC_ALL, $dictionary);
@@ -68,8 +66,8 @@ if ($text != NULL) {
 	
     // Load dictionary
     $dictionary = pspell_new($dictionary, "", "", "UTF-8");
-    if ($dictionary == 0) {
-        returnError("Unable to open dictionary " . $dictionary);
+    if (!is_object($dictionary)) {
+	    returnError("Unable to open dictionary");
     }
 
     $skip = FALSE;


### PR DESCRIPTION
Getting below errors with PHP upgrade to 8.3.0

`PHP Fatal error:  Uncaught Error: Call to undefined function get_magic_quotes_gpc() in /opt/zimbra/data/httpd/htdocs/aspell.php:48\nStack trace:\n#0 {main}\n  thrown in /opt/zimbra/data/httpd/htdocs/aspell.php on line 48`

`Error 8: Object of class PSpell\\Dictionary could not be converted to int`
